### PR TITLE
feat(server): add server.js setup for Apollo Server  Added the server…

### DIFF
--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,4 +1,4 @@
-// boilerplate connection
+// Boilerplate connection.
 
 import mongoose from "mongoose";
 import dotenv from "dotenv";

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const { ApolloServer } = require('@apollo/server');
+const { expressMiddleware } = require('@apollo/server/express4');
+const path = require('path');
+const { authMiddleware } = require('./utils/auth');
+
+const { typeDefs, resolvers } = require('./schemas');
+const db = require('./config/connection');
+
+const PORT = process.env.PORT || 3001;
+const app = express();
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+});
+
+// Create a new instance of an Apollo server with the GraphQL schema.
+const startApolloServer = async () => {
+  await server.start();
+
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
+
+  // Serve up static assets.
+  app.use('/images', express.static(path.join(__dirname, '../client/images')));
+
+  app.use('/graphql', expressMiddleware(server, {
+    context: authMiddleware
+  }));
+
+  if (process.env.NODE_ENV === 'production') {
+    app.use(express.static(path.join(__dirname, '../client/dist')));
+
+    app.get('*', (req, res) => {
+      res.sendFile(path.join(__dirname, '../client/dist/index.html'));
+    });
+  }
+
+  db.once('open', () => {
+    app.listen(PORT, () => {
+      console.log(`API server running on port ${PORT}!`);
+      console.log(`Use GraphQL at http://localhost:${PORT}/graphql`);
+    });
+  });
+};
+
+// Call the async function to start the server.
+startApolloServer();


### PR DESCRIPTION
….js setup which creates a new instance of an Apollo Server with the GraphQL schema, included the Express framework, the database from config/connection, the authMiddleware from utils/auth, and path to construct a path to directories so static files can be served from the dist directory of the client folder.

feat(server): add server.js setup for Apollo Server

Added the server.js setup which creates a new instance of an Apollo Server with the GraphQL schema, included the Express framework, the database from config/connection, the authMiddleware from utils/auth, and path to construct a path to directories so static files can be served from the dist directory of the client folder.