### PR TITLE
feat(schema): add type definitions for GraphQL schema  Added type def…

### DIFF
--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -1,0 +1,48 @@
+const typeDefs = `
+  type Product {
+    _id: ID
+    name: String
+    description: String
+    price: Float
+  }
+
+  type Order {
+    _id: ID
+    purchaseDate: String
+    products: [Product]
+  }
+
+  type User {
+    _id: ID
+    firstName: String
+    lastName: String
+    email: String
+    orders: [Order]
+  }
+
+  type Checkout {
+    session: ID
+  }
+
+  type Auth {
+    token: ID
+    user: User
+  }
+
+  type Query {
+    products: [Product]
+    product(_id: ID!): Product
+    user: User
+    order(_id: ID!): Order
+    checkout(products: [ID]!): Checkout
+  }
+
+  type Mutation {
+    addUser(firstName: String!, lastName: String!, email: String!, password: String!): Auth
+    addOrder(products: [ID]!): Order
+    updateUser(firstName: String, lastName: String, email: String, password: String): User
+    login(email: String!, password: String!): Auth
+  }
+`;
+
+module.exports = typeDefs;


### PR DESCRIPTION
…initions for the GraphQL schema in typeDefs. This includes types for Product, Order, User, Checkout, and Auth. Defined queries for fetching products, a single product by ID, the current user, an order by ID, and a checkout session. Defined mutations for adding a user, adding an order, updating a user, and logging in a user.

feat(schema): add type definitions for GraphQL schema

Added type definitions for the GraphQL schema in typeDefs. This includes types for Product, Order, User, Checkout, and Auth. Defined queries for fetching products, a single product by ID, the current user, an order by ID, and a checkout session. Defined mutations for adding a user, adding an order, updating a user, and logging in a user.