### PR TITLE
feat(schema): export typeDefs and resolvers Added the export of typeD…

### DIFF
--- a/server/schemas/index.js
+++ b/server/schemas/index.js
@@ -1,0 +1,3 @@
+const typeDefs = require('./typeDefs');
+const resolvers = require('./resolvers');
+module.exports = { typeDefs, resolvers };

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,10 +1,9 @@
-const { User, Product, Category, Order } = require("../models");
+const { User, Product, Order } = require("../models");
 const { signToken, AuthenticationError } = require("../utils/auth");
 const stripe = require("stripe")("");
-
 const resolvers = {
   Query: {
-    products: async (parent, {}) => {
+    products: async (parent, { }) => {
       return await Product.find();
     },
     product: async (parent, { _id }) => {
@@ -14,54 +13,42 @@ const resolvers = {
       if (context.user) {
         const user = await User.findById(context.user._id).populate({
           path: "orders.products",
-          populate: "category",
         });
-
         user.orders.sort((a, b) => b.purchaseDate - a.purchaseDate);
-
         return user;
       }
-
       throw AuthenticationError;
     },
     order: async (parent, { _id }, context) => {
       if (context.user) {
         const user = await User.findById(context.user._id).populate({
           path: "orders.products",
-          populate: "category",
         });
-
         return user.orders.id(_id);
       }
-
       throw AuthenticationError;
     },
     checkout: async (parent, args, context) => {
       const url = new URL(context.headers.referer).origin;
       const order = new Order({ products: args.products });
       const line_items = [];
-
       const { products } = await order.populate("products");
-
       for (let i = 0; i < products.length; i++) {
         const product = await stripe.products.create({
           name: products[i].name,
           description: products[i].description,
           images: [`${url}/images/${products[i].image}`],
         });
-
         const price = await stripe.prices.create({
           product: product.id,
           unit_amount: products[i].price * 100,
           currency: "usd",
         });
-
         line_items.push({
           price: price.id,
           quantity: 1,
         });
       }
-
       const session = await stripe.checkout.sessions.create({
         payment_method_types: ["card"],
         line_items,
@@ -69,7 +56,6 @@ const resolvers = {
         success_url: `${url}/success?session_id={CHECKOUT_SESSION_ID}`,
         cancel_url: `${url}/`,
       });
-
       return { session: session.id };
     },
   },
@@ -77,20 +63,16 @@ const resolvers = {
     addUser: async (parent, args) => {
       const user = await User.create(args);
       const token = signToken(user);
-
       return { token, user };
     },
     addOrder: async (parent, { products }, context) => {
       if (context.user) {
         const order = new Order({ products });
-
         await User.findByIdAndUpdate(context.user._id, {
           $push: { orders: order },
         });
-
         return order;
       }
-
       throw AuthenticationError;
     },
     updateUser: async (parent, args, context) => {
@@ -99,27 +81,20 @@ const resolvers = {
           new: true,
         });
       }
-
       throw AuthenticationError;
     },
     login: async (parent, { email, password }) => {
       const user = await User.findOne({ email });
-
       if (!user) {
         throw AuthenticationError;
       }
-
       const correctPw = await user.isCorrectPassword(password);
-
       if (!correctPw) {
         throw AuthenticationError;
       }
-
       const token = signToken(user);
-
       return { token, user };
     },
   },
 };
-
 module.exports = resolvers;


### PR DESCRIPTION
…efs and resolvers by requiring the typeDefs from './typeDefs' and the resolvers from './resolvers', then exporting them as an object. Also removed the  resolver from resolvers.js as it was redundant and eliminated the population of the  document in the user, product, and order resolver